### PR TITLE
Add background custom flag work

### DIFF
--- a/helpers/ifCond.js
+++ b/helpers/ifCond.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports.register = function(handlebars, config) {
+  config = config || {};
+
+  handlebars.registerHelper('ifCond', function(condition1, condition2, options) {
+    if(condition1 === condition2) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  });
+};
+

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
                   {{#if markup}}
                     <div>
                       <div class="comp-lib-pattern-example">
-                        <div class="comp-lib-pattern-component comp-lib-clearfix">
+                        <div class="comp-lib-pattern-component comp-lib-clearfix{{#ifCond background 'dark'}} comp-lib-pattern-component--dark{{/ifCond}}">
                           {{{markup}}}
                         </div>
                         <div class="comp-lib-code-example">
@@ -173,7 +173,7 @@
                         <div class="comp-lib-description">
                           {{{description}}}
                         </div>
-                        <div class="comp-lib-pattern-component comp-lib-clearfix">
+                        <div class="comp-lib-pattern-component comp-lib-clearfix{{#ifCond background 'dark'}} comp-lib-pattern-component--dark{{/ifCond}}">
                           {{{markup}}}
                         </div>
                         <div class="comp-lib-code-example">

--- a/public/assets/stylesheets/component-library.css
+++ b/public/assets/stylesheets/component-library.css
@@ -83,6 +83,9 @@
 .comp-lib-pattern-component .grid-layout {
   font-size: .8em;
 }
+.comp-lib-pattern-component--dark {
+  background-color: #6f777b;
+}
 .comp-lib-description code,
 .comp-lib-pattern-markdown code {
   border: none !important;


### PR DESCRIPTION
# custom background flag work
- ifConditional handlebars helper
- dark css selector
- added conditional to apply styles when `Background: dark` is in a `component library` comment
### Example Screenshot

<img width="607" alt="screen shot 2016-06-14 at 16 26 58" src="https://cloud.githubusercontent.com/assets/2305016/16049520/eab5394e-324f-11e6-8938-3158e768cf67.png">
