### PR TITLE
add extra margin under the example element

### DIFF
--- a/public/assets/stylesheets/component-library.css
+++ b/public/assets/stylesheets/component-library.css
@@ -46,6 +46,7 @@
 .comp-lib-description {
   line-height: 1.5;
   padding-bottom: 1em;
+  margin-bottom: 1em;
 }
 .comp-lib-description--experimental {
   border-left: 4px solid #af1324;


### PR DESCRIPTION
### Before

![screen shot 2016-06-16 at 16 41 06](https://cloud.githubusercontent.com/assets/2305016/16123431/c9b1638c-33e2-11e6-894d-ea431c51cda8.png)
### After

![screen shot 2016-06-16 at 16 53 14](https://cloud.githubusercontent.com/assets/2305016/16123448/d7e016ec-33e2-11e6-854f-2eb6cbb5ea06.png)
