### PR TITLE
Hackpad links

### DIFF
--- a/helpers/setVariable.js
+++ b/helpers/setVariable.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports.register = function(handlebars, config) {
+  config = config || {};
+
+  handlebars.registerHelper('setSectionData', function(key, value, options) {
+    var rootName = options.data.root.rootName;
+    var section = options.data.root.styleguide.section(rootName + '.*');
+
+    section[0].data[key] = value;
+  });
+};

--- a/index.html
+++ b/index.html
@@ -123,13 +123,28 @@
                 </div>
               {{else}}
                 {{#eachSection rootName}}
+                  {{#if discussion}}
+                    {{setSectionData "discussion" discussion}}
+                  {{/if}}
+                {{/eachSection}}
+
+                {{#eachSection rootName}}
                   {{#ifDepth 1}}
                     <div id="kssref-{{referenceURI}}">
                   {{else}}
                     <section id="kssref-{{referenceURI}}">
                   {{/ifDepth}}
                   <div>
-                    <h{{depth}}><a href="#kssref-{{referenceURI}}" class="comp-lib-menu-link">{{header}}</a></h{{depth}}>
+                    <h{{depth}}>
+                      <a href="#kssref-{{referenceURI}}" class="comp-lib-menu-link">{{header}}</a>
+                    </h{{depth}}>
+                    {{#ifCond depth 1}}
+                      {{#if discussion}}
+                        <div class="alert alert--info alert--info__light" role="alert">
+                          <p class="alert__message">Discuss this component on <a href="{{discussion}}">Hackpad</a></p>
+                        </div>
+                      {{/if}}
+                    {{/ifCond}}
                   {{#if parameters}}
                     <ul>
                     {{#eachParameter}}


### PR DESCRIPTION
# Problem

It wasn't obvious where discussion should take place around the components in the library
# Solution

Add a `Discussion:` flag that accepts a URL to where discussion takes place. For our use case it's hackpad

![image](https://cloud.githubusercontent.com/assets/1752124/16340389/d6ea8b1c-3a1f-11e6-8f59-1f2d77e42937.png)
