### PR TITLE
Add background colours to show layouts more clearly

### DIFF
--- a/public/assets/stylesheets/component-library.css
+++ b/public/assets/stylesheets/component-library.css
@@ -76,6 +76,12 @@
 .comp-lib-pattern-example {
   margin-bottom: 4em;
 }
+.comp-lib-pattern-component #wrapper,
+.comp-lib-pattern-component .sidebar,
+.comp-lib-pattern-component .content__body,
+.comp-lib-pattern-component .centered-content {
+  background: rgba(127,127,127,0.2);
+}
 .comp-lib-pattern-component .grid-layout__column {
   background-color: #dee0e2;
   padding: 1em;


### PR DESCRIPTION
# Problem

It was impossible to work out what the layouts where doing without diving into dev tools...

![image](https://cloud.githubusercontent.com/assets/1752124/16806670/554b2c40-490d-11e6-9300-fd047d7ebbb7.png)
# Solution

Add a transparent background colour to those elements that darkens when layered...

![image](https://cloud.githubusercontent.com/assets/1752124/16806689/73c33dca-490d-11e6-86eb-04bbb4edb9db.png)
