### PR TITLE
[FE-222] Feedback box

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,31 +89,12 @@
         <h1 class="heading-48">Component Library</h1>
         <div class="alert alert--info">
           <p class="alert__message">
-            The component library is a snapshot of the work found in assets-frontend. Currently assets-frontend is being refactored.
+            This component library is a visual representation of the styles used to build HMRC's services
           </p>
-          <h2>Discussing Changes</h2>
-          <p class="alert__message">Every component page in the Component Library has a link to the
-            <a href="https://hmrcdigital.hackpad.com/collection/EU4v7qZDRel">HMRC Digital Hackpad</a> page of the same name.
-            This will be the place to discuss what you would like for you components.
-          </p>
-          <h2>Questions</h2>
+          <h3>Questions and Issues</h3>
           <p class="alert__message">
-            We have Slack channels for questions around the Component Library. You'll need a government email address to join them.
-            <ul>
-              <li>
-                <a href="https://hmrcdigital.slack.com/messages/community-ux/">Slack channel for Community UX</a>
-              </li>
-              <li>
-                <a href="https://hmrcdigital.slack.com/messages/community-frontend/">Slack channel for Community Frontend</a>
-              </li>
-            </ul>
-          </p>
-          <h2>Issues</h2>
-          <p class="alert__message">If you see a problem with a component raise an issue in
-            <a href="https://github.com/hmrc/assets-frontend/issues">HMRC assets-fronted issues</a>
-          </p>
-          <p class="alert__message">If you see a problem on the <strong>component library template</strong> raise an issue in
-            <a href="https://github.com/hmrc/component-library-template/issues">HMRC component-library-template issues</a>
+          If you have questions about how to use either a component or the library, or would like to report an issue then please get in touch using one of our
+            <a href="http://hmrc.github.io/assets-frontend#support-and-feedback">support channels</a>.
           </p>
         </div>
         <div class="comp-lib">

--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
                     </h{{depth}}>
                     {{#ifCond depth 1}}
                       {{#if discussion}}
-                        <div class="alert alert--info alert--info__light" role="alert">
+                        <div class="alert alert--info" role="alert">
                           <p class="alert__message">Discuss this component on <a href="{{discussion}}">Hackpad</a></p>
                         </div>
                       {{/if}}

--- a/index.html
+++ b/index.html
@@ -87,6 +87,35 @@
           </div>
         </div>
         <h1 class="heading-48">Component Library</h1>
+        <div class="alert alert--info">
+          <p class="alert__message">
+            The component library is a snapshot of the work found in assets-frontend. Currently assets-frontend is being refactored.
+          </p>
+          <h2>Discussing Changes</h2>
+          <p class="alert__message">Every component page in the Component Library has a link to the
+            <a href="https://hmrcdigital.hackpad.com/collection/EU4v7qZDRel">HMRC Digital Hackpad</a> page of the same name.
+            This will be the place to discuss what you would like for you components.
+          </p>
+          <h2>Questions</h2>
+          <p class="alert__message">
+            We have Slack channels for questions around the Component Library. You'll need a government email address to join them.
+            <ul>
+              <li>
+                <a href="https://hmrcdigital.slack.com/messages/community-ux/">Slack channel for Community UX</a>
+              </li>
+              <li>
+                <a href="https://hmrcdigital.slack.com/messages/community-frontend/">Slack channel for Community Frontend</a>
+              </li>
+            </ul>
+          </p>
+          <h2>Issues</h2>
+          <p class="alert__message">If you see a problem with a component raise an issue in
+            <a href="https://github.com/hmrc/assets-frontend/issues">HMRC assets-fronted issues</a>
+          </p>
+          <p class="alert__message">If you see a problem on the <strong>component library template</strong> raise an issue in
+            <a href="https://github.com/hmrc/component-library-template/issues">HMRC component-library-template issues</a>
+          </p>
+        </div>
         <div class="comp-lib">
 
           <aside class="comp-lib-sidebar">

--- a/public/assets/stylesheets/component-library.css
+++ b/public/assets/stylesheets/component-library.css
@@ -116,7 +116,6 @@
   list-style-position: inside;
   margin: 0;
   padding-left: 1.2em;
-  margin-bottom: 2em;
 }
 .comp-lib-pattern-markdown p {
   line-height: 1.5;


### PR DESCRIPTION
# Feedback box
- added feedback box with links to the homepage that contains:
  - Discussion
  - Questions
  - Issues
- updated hackpad links in component pages to have the same colour as the feedback box
## Screenshot

![screen shot 2016-07-21 at 16 02 27](https://cloud.githubusercontent.com/assets/2305016/17027670/b4483288-4f5c-11e6-96db-0ba2ea536b29.png)
