### PR TITLE
Add template for new assets-frontend structure

### DIFF
--- a/new-structure.html
+++ b/new-structure.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="lte-ie8" lang="en"><![endif]-->
+<!--[if gt IE 8]><!--><html lang="en"><!--<![endif]-->
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+
+    <title>Component library - HM Revenue &amp; Customs</title>
+
+    <script type="text/javascript">
+      (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
+    </script>
+
+    <link rel="stylesheet" href="public/assets/stylesheets/component-library.css">
+
+    <!--[if gt IE 8]><!--><link href="public/assets/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+    <!--[if IE 6]><link href="public/assets/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if IE 7]><link href="public/assets/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if IE 8]><link href="public/assets/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+
+    <link href="public/assets/stylesheets/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+
+    <!--[if IE 8]>
+    <script type="text/javascript">
+      (function(){if(window.opera){return;}
+       setTimeout(function(){var a=document,g,b={families:(g=
+       ["nta"]),urls:["public/assets/stylesheets/fonts-ie8.css"]},
+       c="public/assets/javascripts/vendor/goog/webfont-debug.js",d="script",
+       e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
+       ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
+       .className+=' wf-'+g[h].replace(/\s/g,'').toLowerCase()+'-n4-loading');},0)
+      })()
+    </script>
+    <![endif]-->
+    <!--[if gte IE 9]><!-->
+      <link href="public/assets/stylesheets/fonts.css" media="all" rel="stylesheet" type="text/css" />
+    <!--<![endif]-->
+
+
+    <!--[if lt IE 9]>
+      <script src="public/assets/javascripts/ie.js" type="text/javascript"></script>
+    <![endif]-->
+
+
+    <link rel="stylesheet" href="public/assets/stylesheets/vendor/highlight/github.css">
+
+    <link rel="shortcut icon" href="public/assets/images/favicon.ico" type="image/x-icon" />
+
+    <!-- Size for iPad and iPad mini (high resolution) -->
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="public/assets/images/apple-touch-icon-152x152.png">
+    <!-- Size for iPhone and iPod touch (high resolution) -->
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="public/assets/images/apple-touch-icon-120x120.png">
+    <!-- Size for iPad 2 and iPad mini (standard resolution) -->
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="public/assets/images/apple-touch-icon-76x76.png">
+    <!-- Default non-defined size, also used for Android 2.1+ devices -->
+    <link rel="apple-touch-icon-precomposed" href="public/assets/images/apple-touch-icon-60x60.png">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta property="og:image" content="public/assets/images/opengraph-image.png">
+
+    {{{styles}}}
+  </head>
+
+  <body class="no-js">
+    <header role="banner" id="global-header">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
+              <img src="public/assets/images/gov.uk_logotype_crown_invert_trans.png" width="35" height="31" alt=""> GOV.UK
+            </a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main id="wrapper">
+      <div class="comp-lib-content">
+
+        <div class="service-info">
+          <div class="alpha-banner">
+            <p>
+              <strong class="phase-tag">ALPHA</strong><span>This is a trial service.</span>
+            </p>
+          </div>
+          <div class="logo">
+            <span class="organisation-logo organisation-logo-medium">HM Revenue &amp; Customs</span>
+          </div>
+        </div>
+        <h1 class="heading-48">Component Library</h1>
+        <div class="alert alert--info">
+          <p class="alert__message">
+            This component library is a visual representation of the styles used to build HMRC's services.
+          </p>
+          <h3>Questions and Issues</h3>
+          <p class="alert__message">
+          If you have questions about how to use either a component or the library, or would like to report an issue then please get in touch using one of our
+            <a href="http://hmrc.github.io/assets-frontend#support-and-feedback">support channels</a>.
+          </p>
+        </div>
+        <div class="comp-lib">
+
+          <aside class="comp-lib-sidebar">
+            <nav>
+              <ul>
+                <li class="comp-lib-menu-item">
+                  <a href="./" class="comp-lib-menu-link">Home</a>
+                </li>
+              </ul>
+            </nav>
+          </aside>
+
+          <div id="content">
+            <article class="comp-lib-main">
+            {{#if description}}
+              <div class="comp-lib-description">
+                {{{description}}}
+              </div>
+            {{/if}}
+
+            <!-- pattern examples -->
+            {{#if markup}}
+              <div class="comp-lib-pattern-example">
+                <div class="comp-lib-pattern-component comp-lib-clearfix">
+                  {{{markup}}}
+                </div>
+                <div class="comp-lib-code-example">
+                  <pre class="comp-lib-pre"><code class="comp-lib-code html">{{markup}}</code></pre>
+                </div>
+              </div>
+            {{/if}}
+            </article>
+          </div>
+        </div>
+    </div>
+  </main>
+
+    <footer class="group js-footer" id="footer" role="contentinfo">
+      <div class="footer-wrapper">
+        <div class="footer-meta">
+          <div class="footer-meta-inner">
+            <div class="open-government-licence">
+              <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+                <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+            </div>
+          </div>
+
+          <div class="copyright">
+            <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <!--end footer-->
+
+    <script src="public/assets/javascripts/vendor/highlight/highlight.pack.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+
+    <script type="text/javascript">
+      document.body.className = document.body.className.replace('no-js', 'js') + ' js-enabled';
+    </script>
+    <script src="public/assets/javascripts/vendor/kss/kss.js"></script>
+    {{{scripts}}}
+  </body>
+</html>


### PR DESCRIPTION
# Problem

The original template for components in assets-frontend works for kss-node, but the new structure has a much simpler interface.

#  Solution

Add a new template with template tags for `styles`, `scripts`, `description`, and `markup` only.