### PR TITLE
Add styles for scaled examples

### DIFF
--- a/public/assets/stylesheets/component-library.css
+++ b/public/assets/stylesheets/component-library.css
@@ -140,3 +140,27 @@
   color: #df3034;
   text-decoration: underline;
 }
+
+/* Scaled component examples */
+.scale-wrapper {
+  margin-bottom: em(20, 16);
+  overflow: hidden;
+}
+
+.scale {
+  -ms-transform: scale(0.5);
+  -moz-transform: scale(0.5);
+  -o-transform: scale(0.5);
+  -webkit-transform: scale(0.5);
+  transform: scale(0.5);
+
+  -ms-transform-origin: 0 0;
+  -moz-transform-origin: 0 0;
+  -o-transform-origin: 0 0;
+  -webkit-transform-origin: 0 0;
+  transform-origin: 0 0;
+  width: 200%;
+  border: 2px solid #bfc1c3;
+  padding: 20px;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
# Problem

The examples aren't scaled to represent how they look in a desktop browser.

![image](https://user-images.githubusercontent.com/1752124/29228533-5dbf0866-7eda-11e7-8fe6-6d9b2452a4fd.png)


# Solution

Add styles that transform the example down by half and make the width 200% so the desktop media queries kick in.

![image](https://user-images.githubusercontent.com/1752124/29228543-6a2d6b1a-7eda-11e7-9555-eefff629d2fd.png)
