### PR TITLE
Removed wording about not using this in your service

### DIFF
--- a/design-system.html
+++ b/design-system.html
@@ -61,7 +61,7 @@
         <div class="design-system phase-banner">
           <p>
             <strong class="phase-tag">ALPHA</strong>
-            <span>This is a prototype – do not use this guidance in your service</span>
+            <span>This is a prototype</span>
           </p>
         </div>
 


### PR DESCRIPTION
## Problem

The Alpha banner tells people "This is a prototype – do not use this guidance in your service"

We don't want people to get confused and not use the patterns in AF so we can remove this.

## Solution

Changed the content to just say "This is a prototype"