### PR TITLE
Add path prefix to design system template

### DIFF
--- a/design-system.html
+++ b/design-system.html
@@ -8,22 +8,22 @@
 
     <title>HMRC Design System</title>
 
-    <link rel="icon" type="image/x-icon" href="/public/images/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="{{ pathPrefix }}/public/images/favicon.ico" />
 
-    <link rel="stylesheet" href="/public/assets/stylesheets/design-system.css">
-    <link rel="stylesheet" href="/public/assets/stylesheets/vendor/highlight/github.css">
+    <link rel="stylesheet" href="{{ pathPrefix }}/public/assets/stylesheets/design-system.css">
+    <link rel="stylesheet" href="{{ pathPrefix }}/public/assets/stylesheets/vendor/highlight/github.css">
 
-    <!--[if gt IE 8]><!--><link href="/public/assets/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-    <!--[if IE 6]><link href="/public/assets/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-    <!--[if IE 7]><link href="/public/assets/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-    <!--[if IE 8]><link href="/public/assets/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if gt IE 8]><!--><link href="{{ pathPrefix }}/public/assets/stylesheets/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+    <!--[if IE 6]><link href="{{ pathPrefix }}/public/assets/stylesheets/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if IE 7]><link href="{{ pathPrefix }}/public/assets/stylesheets/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if IE 8]><link href="{{ pathPrefix }}/public/assets/stylesheets/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-    <!--[if gt IE 8]><!--><link rel="stylesheet" href="/public/stylesheets/application.min.css"><!--<![endif]-->
-    <!--[if lte IE 8]><link rel="stylesheet" href="/public/stylesheets/application-ie.min.css"><![endif]-->
+    <!--[if gt IE 8]><!--><link rel="stylesheet" href="{{ pathPrefix }}/public/stylesheets/application.min.css"><!--<![endif]-->
+    <!--[if lte IE 8]><link rel="stylesheet" href="{{ pathPrefix }}/public/stylesheets/application-ie.min.css"><![endif]-->
 
     {{{styles}}}
 
-    <script src="/public/assets/javascripts/vendor/modernizr.js"></script>
+    <script src="{{ pathPrefix }}/public/assets/javascripts/vendor/modernizr.js"></script>
   </head>
 
   <body class="{{#if homepage}}homepage{{/if}}">
@@ -36,7 +36,7 @@
             <div class="design-system-header__brand">
                 <a href="/">
                   <span class="design-system-govuk-logo">
-                    <img class="design-system-govuk-logo__printable-crown" src="/public/assets/images/gov.uk_logotype_crown_invert_trans.png" height="32" width="36">
+                    <img class="design-system-govuk-logo__printable-crown" src="{{ pathPrefix }}/public/assets/images/gov.uk_logotype_crown_invert_trans.png" height="32" width="36">
                     GOV.UK
                   </span>
 
@@ -240,7 +240,7 @@
       </div>
     </div>
 
-    <script src="/public/assets/javascripts/vendor/highlight/highlight.pack.js"></script>
+    <script src="{{ pathPrefix }}/public/assets/javascripts/vendor/highlight/highlight.pack.js"></script>
     <script>
       hljs.initHighlightingOnLoad();
 
@@ -261,6 +261,6 @@
 
     {{{scripts}}}
 
-    <script src="/public/javascripts/application.min.js"></script>
+    <script src="{{ pathPrefix }}/public/javascripts/application.min.js"></script>
   </body>
 </html>

--- a/design-system.html
+++ b/design-system.html
@@ -68,7 +68,7 @@
         <div class="sub-nav">
           <ul class="sub-nav-list">
           {{#each sections}}
-            <li><a href="{{ url }}">{{ titleCase title }}</a></li>
+            <li><a href="{{ pathPrefix }}{{ url }}">{{ titleCase title }}</a></li>
           {{/each}}
            </ul>
         </div>
@@ -83,7 +83,7 @@
             <nav id="toc" class="js-toc-list toc__list">
               <ul class="pattern-nav">
               {{#each nav}}
-                <li><a href="{{ url }}">{{ titleCase title }}</a></li>
+                <li><a href="{{ pathPrefix }}{{ url }}">{{ titleCase title }}</a></li>
               {{/each}}
               <ul>
             </nav>


### PR DESCRIPTION
The github pages url is a subdirectory (i.e. http://hmrc.github.io/assets-frontend/) so we need to prepend the directory to the absolute asset urls.