### PR TITLE
disable click for anchors in example blocks

### DIFF
--- a/design-system.html
+++ b/design-system.html
@@ -242,23 +242,7 @@
     </div>
 
     <script src="public/assets/javascripts/vendor/highlight/highlight.pack.js"></script>
-    <script>
-      hljs.initHighlightingOnLoad();
-
-      function scaleExampleHeight() {
-        var scaleWrapper = document.querySelectorAll('.scale-wrapper')
-
-        for (var i = 0; i <= scaleWrapper.length - 1; i++) {
-          scaleWrapper[i].style.height = scaleWrapper[i].querySelector('.scale').offsetHeight / 2 + 'px'
-        }
-      }
-
-      window.addEventListener('resize', function() {
-        scaleExampleHeight()
-      })
-
-      scaleExampleHeight()
-    </script>
+    <script src="public/assets/javascripts/design-system.js"></script>
 
     {{{scripts}}}
 

--- a/public/assets/javascripts/design-system.js
+++ b/public/assets/javascripts/design-system.js
@@ -1,0 +1,29 @@
+(function() {
+  'use strict'
+
+  function preventClickOnExample() {
+    var anchors = document.querySelectorAll('.example a')
+
+    for (var i=0, n=anchors.length;i<n;i++) {
+      anchors[i].addEventListener('click', function(e) {
+        e.preventDefault();
+      })
+    }
+  }
+
+  function scaleExampleHeight() {
+    var scaleWrapper = document.querySelectorAll('.scale-wrapper')
+
+    for (var i = 0; i <= scaleWrapper.length - 1; i++) {
+      scaleWrapper[i].style.height = scaleWrapper[i].querySelector('.scale').offsetHeight / 2 + 'px'
+    }
+  }
+
+  window.addEventListener('resize', function() {
+    scaleExampleHeight()
+  })
+
+  scaleExampleHeight()
+  preventClickOnExample()
+  hljs.initHighlightingOnLoad()
+})()

--- a/public/assets/javascripts/design-system.js
+++ b/public/assets/javascripts/design-system.js
@@ -1,11 +1,11 @@
-(function() {
+(function () {
   'use strict'
 
   function preventClickOnExample() {
     var anchors = document.querySelectorAll('.example a')
 
-    for (var i=0, n=anchors.length;i<n;i++) {
-      anchors[i].addEventListener('click', function(e) {
+    for (var i = 0, n = anchors.length; i < n; i++) {
+      anchors[i].addEventListener('click', function (e) {
         e.preventDefault();
       })
     }
@@ -14,12 +14,12 @@
   function scaleExampleHeight() {
     var scaleWrapper = document.querySelectorAll('.scale-wrapper')
 
-    for (var i = 0; i <= scaleWrapper.length - 1; i++) {
+    for (var i = 0, n = scaleWrapper.length; i < n; i++) {
       scaleWrapper[i].style.height = scaleWrapper[i].querySelector('.scale').offsetHeight / 2 + 'px'
     }
   }
 
-  window.addEventListener('resize', function() {
+  window.addEventListener('resize', function () {
     scaleExampleHeight()
   })
 


### PR DESCRIPTION
### Problem
Clicking a link in example markup navigates to a 404.

## Solution
Prevent default behaviour for anchors inside example wrappers.