### PR TITLE
Get latest masthead style from GDS prototype

### DIFF
--- a/public/assets/stylesheets/design-system/modules/_masthead.scss
+++ b/public/assets/stylesheets/design-system/modules/_masthead.scss
@@ -15,8 +15,6 @@
   background-color: $govuk-blue;
   padding: $gutter;
   color: white;
-  width: 101%;
-  margin-left: -32px;
 
   @include media(mobile) {
     padding: $gutter-half;


### PR DESCRIPTION
Use the same style a GDS uses for masthead. [Reference](https://github.com/alphagov/govuk-design-system-prototypes/blob/c2e5591336570be2bd80cd5650b709a15c6a995c/source/stylesheets/modules/_masthead.scss)