### PR TITLE
Sdt 695 ds layout issues

### DIFF
--- a/public/assets/stylesheets/design-system.css
+++ b/public/assets/stylesheets/design-system.css
@@ -1138,6 +1138,9 @@ main {
       line-height: 1.25;
       background: #6f777b;
       color: white; }
+  .markdown .column-one-third > h2 {
+    padding-top: 30px;
+    margin-top: 15px; }
   .markdown > h4 {
     font-weight: 700; }
   .markdown pre {

--- a/public/assets/stylesheets/design-system.css
+++ b/public/assets/stylesheets/design-system.css
@@ -489,9 +489,7 @@
 .masthead {
   background-color: #005ea5;
   padding: 30px;
-  color: white;
-  width: 101%;
-  margin-left: -32px; }
+  color: white; }
   @media (max-width: 767px) {
     .masthead {
       padding: 15px; } }
@@ -1140,6 +1138,8 @@ main {
       line-height: 1.25;
       background: #6f777b;
       color: white; }
+  .markdown > h4 {
+    font-weight: 700; }
   .markdown pre {
     padding: 0; }
     .markdown pre code {

--- a/public/assets/stylesheets/design-system.css
+++ b/public/assets/stylesheets/design-system.css
@@ -1141,8 +1141,6 @@ main {
   .markdown .column-one-third > h2 {
     padding-top: 30px;
     margin-top: 15px; }
-  .markdown > h4 {
-    font-weight: 700; }
   .markdown pre {
     padding: 0; }
     .markdown pre code {

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -117,10 +117,6 @@ main {
     margin-top: 15px;
   }
 
-  > h4 {
-    font-weight: 700;
-  }
-
   pre {
     padding: 0;
 

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -112,6 +112,11 @@ main {
     }
   }
 
+  .column-one-third > h2 {
+    padding-top: 30px;
+    margin-top: 15px;
+  }
+
   > h4 {
     font-weight: 700;
   }

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -112,6 +112,10 @@ main {
     }
   }
 
+  > h4 {
+    font-weight: 700;
+  }
+
   pre {
     padding: 0;
 


### PR DESCRIPTION
## Solution
Add overrides for `h2` padding  in 1/3 columns to have the same look'n'feel as GOVUK prototype page.

### Screenshot
<img width="1010" alt="screen shot 2017-10-31 at 11 48 12" src="https://user-images.githubusercontent.com/18576086/32222526-7b565492-be31-11e7-8ec7-36e0637d765e.png">
