### PR TITLE
Use gds styles for heading in the technical documentation

### DIFF
--- a/public/assets/stylesheets/design-system.css
+++ b/public/assets/stylesheets/design-system.css
@@ -1159,7 +1159,6 @@ main {
     text-transform: none;
     font-size: 32px;
     line-height: 1.09375;
-    font-size: 48px;
     margin-top: 0.46875em;
     margin-bottom: 0.9375em; }
     @media (min-width: 768px) {

--- a/public/assets/stylesheets/design-system.css
+++ b/public/assets/stylesheets/design-system.css
@@ -41,6 +41,17 @@
 .grid-row, .hero__content {
   margin: 0 -15px; }
 
+.visually-hidden,
+.visuallyhidden {
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0; }
+
 #content {
   padding-bottom: 30px;
   outline: none; }
@@ -1141,6 +1152,82 @@ main {
   .markdown .column-one-third > h2 {
     padding-top: 30px;
     margin-top: 15px; }
+  .markdown > h1,
+  .markdown > .heading-xlarge {
+    font-family: "nta", Arial, sans-serif;
+    font-weight: 700;
+    text-transform: none;
+    font-size: 32px;
+    line-height: 1.09375;
+    font-size: 48px;
+    margin-top: 0.46875em;
+    margin-bottom: 0.9375em; }
+    @media (min-width: 768px) {
+      .markdown > h1,
+      .markdown > .heading-xlarge {
+        font-size: 48px;
+        line-height: 1.04167; } }
+    @media (min-width: 768px) {
+      .markdown > h1,
+      .markdown > .heading-xlarge {
+        margin-top: 0.625em;
+        margin-bottom: 1.25em; } }
+  .markdown > h2,
+  .markdown > .heading-large {
+    font-family: "nta", Arial, sans-serif;
+    font-weight: 700;
+    text-transform: none;
+    font-size: 24px;
+    line-height: 1.04167;
+    margin-top: 1.04167em;
+    margin-bottom: 0.41667em; }
+    @media (min-width: 768px) {
+      .markdown > h2,
+      .markdown > .heading-large {
+        font-size: 36px;
+        line-height: 1.11111; } }
+    @media (min-width: 768px) {
+      .markdown > h2,
+      .markdown > .heading-large {
+        margin-top: 1.25em;
+        margin-bottom: 0.55556em; } }
+  .markdown > h3,
+  .markdown > .heading-medium {
+    font-family: "nta", Arial, sans-serif;
+    font-weight: 700;
+    text-transform: none;
+    font-size: 18px;
+    line-height: 1.2;
+    margin-top: 1.25em;
+    margin-bottom: 0.5em; }
+    @media (min-width: 768px) {
+      .markdown > h3,
+      .markdown > .heading-medium {
+        font-size: 24px;
+        line-height: 1.25; } }
+    @media (min-width: 768px) {
+      .markdown > h3,
+      .markdown > .heading-medium {
+        margin-top: 1.875em;
+        margin-bottom: 0.83333em; } }
+  .markdown > h4,
+  .markdown > .heading-small {
+    font-family: "nta", Arial, sans-serif;
+    font-weight: 700;
+    text-transform: none;
+    font-size: 16px;
+    line-height: 1.25;
+    margin-top: 0.625em;
+    margin-bottom: 0.3125em; }
+    @media (min-width: 768px) {
+      .markdown > h4,
+      .markdown > .heading-small {
+        font-size: 19px;
+        line-height: 1.31579; } }
+    @media (min-width: 768px) {
+      .markdown > h4,
+      .markdown > .heading-small {
+        margin-top: 1.05263em; } }
   .markdown pre {
     padding: 0; }
     .markdown pre code {

--- a/public/assets/stylesheets/design-system.scss
+++ b/public/assets/stylesheets/design-system.scss
@@ -15,6 +15,7 @@ $desktop-breakpoint: 992px !default;
 @import "govuk_frontend_toolkit/stylesheets/typography";
 @import "govuk_frontend_toolkit/stylesheets/url-helpers";
 
+@import "govuk-elements-sass/public/sass/elements/helpers";
 @import "govuk-elements-sass/public/sass/elements/layout";
 
 @import "design-system/palette/syntax-highlighting";

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -120,7 +120,6 @@ main {
   > h1,
   > .heading-xlarge {
     @include bold-48();
-    font-size: 48px;
 
     margin-top: em(15, 32);
     margin-bottom: em(30, 32);

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -117,6 +117,54 @@ main {
     margin-top: 15px;
   }
 
+  > h1 {
+    font-size: 48px;
+
+    margin-top: em(15, 32);
+    margin-bottom: em(30, 32);
+
+    @include media(tablet) {
+      margin-top: em(30, 48);
+      margin-bottom: em(60, 48);
+    }
+  }
+
+  > h2 {
+    font-size: 36px;
+
+    margin-top: em(25, 24);
+    margin-bottom: em(10, 24);
+
+    @include media(tablet) {
+      margin-top: em(45, 36);
+      margin-bottom: em(20, 36);
+    }
+  }
+
+  > h3 {
+    font-size: 24px;
+
+    margin-top: em(25, 20);
+    margin-bottom: em(10, 20);
+
+    @include media(tablet) {
+      margin-top: em(45, 24);
+      margin-bottom: em(20, 24);
+    }
+  }
+
+  > h4 {
+    font-size: 19px;
+    font-weight: 700;
+
+    margin-top: em(10, 16);
+    margin-bottom: em(5, 16);
+
+    @include media(tablet) {
+      margin-top: em(20, 19);
+    }
+  }
+
   pre {
     padding: 0;
 

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -117,7 +117,9 @@ main {
     margin-top: 15px;
   }
 
-  > h1 {
+  > h1,
+  > .heading-xlarge {
+    @include bold-48();
     font-size: 48px;
 
     margin-top: em(15, 32);
@@ -129,8 +131,9 @@ main {
     }
   }
 
-  > h2 {
-    font-size: 36px;
+  > h2,
+  > .heading-large {
+    @include bold-36();
 
     margin-top: em(25, 24);
     margin-bottom: em(10, 24);
@@ -141,8 +144,9 @@ main {
     }
   }
 
-  > h3 {
-    font-size: 24px;
+  > h3,
+  > .heading-medium {
+    @include bold-24();
 
     margin-top: em(25, 20);
     margin-bottom: em(10, 20);
@@ -153,9 +157,9 @@ main {
     }
   }
 
-  > h4 {
-    font-size: 19px;
-    font-weight: 700;
+  > h4,
+  > .heading-small {
+    @include bold-19();
 
     margin-top: em(10, 16);
     margin-bottom: em(5, 16);


### PR DESCRIPTION
## Solution
Update `h1`,  `h2`,  `h3`,  `h4` styles according to [govuk_elements](https://github.com/alphagov/govuk_elements/blob/dfb8f4bd9f6b3b9066a84d81d6424cd361a7364c/assets/sass/elements/_elements-typography.scss#L72) 

### Screenshots
<img width="753" alt="screen shot 2017-10-31 at 12 37 12" src="https://user-images.githubusercontent.com/18576086/32224238-86483a44-be38-11e7-89a8-c559da020e35.png">
<img width="715" alt="screen shot 2017-10-31 at 12 37 31" src="https://user-images.githubusercontent.com/18576086/32224239-86add34a-be38-11e7-9d94-abad592c146f.png">
<img width="759" alt="screen shot 2017-10-31 at 12 37 51" src="https://user-images.githubusercontent.com/18576086/32224240-86cdc0b0-be38-11e7-9ee4-23ad81138f49.png">
