### PR TITLE
Stop CSS from bleeding into example blocks

### DIFF
--- a/public/assets/stylesheets/design-system.css
+++ b/public/assets/stylesheets/design-system.css
@@ -1227,32 +1227,37 @@ main {
       .markdown > h4,
       .markdown > .heading-small {
         margin-top: 1.05263em; } }
-  .markdown pre {
+  .markdown > pre {
     padding: 0; }
-    .markdown pre code {
+    .markdown > pre code {
       border: none; }
-  .markdown p, .markdown ul.list, .markdown ol.list, .markdown blockquote, .markdown .example {
+  .markdown > p,
+  .markdown > ul.list,
+  .markdown > ol.list,
+  .markdown > blockquote,
+  .markdown > .example {
     max-width: 34em; }
-  .markdown ul {
+  .markdown > ul {
     list-style: disc; }
-  .markdown ul, .markdown ol {
+  .markdown > ul,
+  .markdown > ol {
     padding: 0 0 0 20px;
     margin: 15px 0 45px; }
-  .markdown ol li {
+  .markdown > ol li {
     list-style-type: decimal; }
-  .markdown ul li {
+  .markdown > ul li {
     list-style-type: disc; }
-  .markdown .example + pre,
-  .markdown .example + .highlight {
+  .markdown > .example + pre,
+  .markdown > .example + .highlight {
     margin-top: -31px; }
-  .markdown .highlight {
+  .markdown > .highlight {
     font-size: 16px; }
-  .markdown blockquote {
+  .markdown > blockquote {
     margin: 15px 0;
     border-left: 4px solid #dee0e2; }
-  .markdown strong {
+  .markdown > strong {
     font-weight: bold; }
-  .markdown .list-no-bullet {
+  .markdown > .list-no-bullet {
     list-style: none;
     padding-left: 0px; }
 

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -168,7 +168,7 @@ main {
     }
   }
 
-  pre {
+  > pre {
     padding: 0;
 
     code {
@@ -176,46 +176,51 @@ main {
     }
   }
 
-  p, ul.list, ol.list, blockquote, .example {
+  > p,
+  > ul.list,
+  > ol.list,
+  > blockquote,
+  > .example {
     max-width: 34em;
   }
 
-  ul {
+  > ul {
     list-style: disc;
   }
 
-  ul, ol {
+  > ul,
+  > ol {
     padding: 0 0 0 20px;
     margin: 15px 0 45px;
   }
 
-  ol li {
+  > ol li {
     list-style-type: decimal;
   }
 
-  ul li {
+  > ul li {
     list-style-type: disc;
   }
 
-  .example + pre,
-  .example + .highlight {
+  > .example + pre,
+  > .example + .highlight {
     margin-top: -31px;
   }
 
-  .highlight {
+  > .highlight {
     font-size: 16px;
   }
 
-  blockquote {
+  > blockquote {
     margin: 15px 0;
     border-left: 4px solid #dee0e2;
   }
 
-  strong {
+  > strong {
     font-weight: bold;
   }
 
-  .list-no-bullet {
+  > .list-no-bullet {
     list-style: none;
     padding-left: 0px;
   }


### PR DESCRIPTION
Adds child selectors so only immediate children of the `markdown` container are styled, preventing children of `example` containers from inadvertently inheriting