### PR TITLE
SDT-723 Make Nav Items Sentence case

### DIFF
--- a/design-system.html
+++ b/design-system.html
@@ -80,7 +80,7 @@
         <div class="sub-nav">
           <ul class="sub-nav-list">
           {{#each sections}}
-            <li><a href="{{ ../pathPrefix }}{{ url }}">{{ titleCase title }}</a></li>
+            <li><a href="{{ ../pathPrefix }}{{ url }}">{{ sentenceCase title }}</a></li>
           {{/each}}
            </ul>
         </div>
@@ -95,7 +95,7 @@
             <nav id="toc" class="js-toc-list toc__list">
               <ul class="pattern-nav">
               {{#each nav}}
-                <li><a href="{{ ../pathPrefix }}{{ url }}">{{ titleCase title }}</a></li>
+                <li><a href="{{ ../pathPrefix }}{{ url }}">{{ sentenceCase title }}</a></li>
               {{/each}}
               <ul>
             </nav>

--- a/helpers/sentenceCase.js
+++ b/helpers/sentenceCase.js
@@ -1,0 +1,10 @@
+module.exports = function sentenceCase (text) {
+  return text
+    .split(/\.[ \-_]/)
+    .map(function (sentence) {
+      return sentence.charAt(0).toUpperCase() + sentence.substr(1).toLowerCase()
+    })
+    .join('.-')
+    .split(/[ \-_]/)
+    .join(' ')
+  }


### PR DESCRIPTION
Added a sentenceCase helper in the style of the titleCase helper and used it in place of the titleCase helper in the navigation item macros.

Went down this path rather than switching to css text-transforms as it was a smaller change. Ad the sentence case helper might be more generally useful too.

Note: The Actual Nav items may not show the sentence casing if there is only one '.' in the name of the directory as the path.name property is being used rather than path.base.