### PR TITLE
SDT-722 Set max-width on lists and tables

### DIFF
--- a/public/assets/stylesheets/design-system.css
+++ b/public/assets/stylesheets/design-system.css
@@ -1232,9 +1232,10 @@ main {
     .markdown > pre code {
       border: none; }
   .markdown > p,
-  .markdown > ul.list,
-  .markdown > ol.list,
+  .markdown > ul,
+  .markdown > ol,
   .markdown > blockquote,
+  .markdown > table,
   .markdown > .example {
     max-width: 34em; }
   .markdown > ul {

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -177,9 +177,10 @@ main {
   }
 
   > p,
-  > ul.list,
-  > ol.list,
+  > ul,
+  > ol,
   > blockquote,
+  > table,
   > .example {
     max-width: 34em;
   }


### PR DESCRIPTION
`ol` and `ul` without a class name of `list` were full width, as were `table` elements. This change applies `max-width` to all list containers and tables that are direct children of the `markdown` parent