### PR TITLE
The ga function now only gets called on copy event

### DIFF
--- a/public/assets/javascripts/design-system.js
+++ b/public/assets/javascripts/design-system.js
@@ -21,9 +21,10 @@
 
   function captureCopyEvents(){
     var codeBlocks = document.querySelectorAll('code')
-
     for (var i = 0, n = codeBlocks.length; i < n; i++){
-      codeBlocks[i].addEventListener('copy', ga('send', 'event', 'markup', 'copy', document.location.pathname))
+      codeBlocks[i].addEventListener('copy', function(){
+        ga('send', 'event', 'markup', 'copy', document.location.pathname)
+      })
     }
 
   }


### PR DESCRIPTION
# Problem
The ga function for tracking copy events is getting fired immediately on page load

# Solution
Add the ga function in the call back and not passed as a parameter