### PR TITLE
SDT-827 unlink from gov.uk design system

### DIFF
--- a/design-system.html
+++ b/design-system.html
@@ -224,7 +224,7 @@
                 <div class="footer__navigation--column">
                   <h2 class="heading-medium">GOV.UK Design System</h2>
                   <ul>
-                    <li><a href="https://govuk-design-system-prototypes.cloudapps.digital/design-patterns/patterns/">Prototype</a></li>
+                    <li><p>The GOV.UK Design-system is in private beta</p></li>
                   </ul>
                 </div>
                 <div class="footer__navigation--column">

--- a/design-system.html
+++ b/design-system.html
@@ -224,7 +224,7 @@
                 <div class="footer__navigation--column">
                   <h2 class="heading-medium">GOV.UK Design System</h2>
                   <ul>
-                    <li><p>The GOV.UK Design-system is in private beta</p></li>
+                    <li><p>The GOV.UK design-system is in private beta</p></li>
                   </ul>
                 </div>
                 <div class="footer__navigation--column">

--- a/public/assets/stylesheets/design-system.css
+++ b/public/assets/stylesheets/design-system.css
@@ -1355,6 +1355,10 @@ dl.meta-data-bottom {
       display: block;
       font-size: 16px;
       padding: 10px 0 0; }
+    .footer-container .footer__navigation ul li p {
+      font-size: 16px;
+      padding: 10px 0 0;
+      margin: 0; }
 
 .footer__navigation--column {
   flex: 1;

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -364,6 +364,12 @@ dl.meta-data-bottom {
       font-size: 16px;
       padding: 10px 0 0;
     }
+
+    & ul li p {
+      font-size: 16px;
+      padding: 10px 0 0;
+      margin: 0;
+    }
   }
 }
 


### PR DESCRIPTION
The GOV.UK design system prototype is linked to from the HMRC design system footer, I've removed the link and added styles to keep the replacement aligned