### PR TITLE
SDT-828 correct mailto link in design-system template

### DIFF
--- a/design-system.html
+++ b/design-system.html
@@ -213,7 +213,7 @@
 
             <div class="callout">
               <h2 class="heading-medium">Get in touch</h2>
-              <p>If you’ve got a question, idea or suggestion share it in <a href="https://hmrcdigital.slack.com/messages/C39V3PH38">#team-sdt</a> on HMRC Slack (<a href="slack://channel?team=T04RY81HB&amp;id=C39V3PH38">open in app</a>) or <a href="hmrc-service-design-tools-g@digital.hmrc.gov.uk">email the Service Design Tools team</a></p>
+              <p>If you’ve got a question, idea or suggestion share it in <a href="https://hmrcdigital.slack.com/messages/C39V3PH38">#team-sdt</a> on HMRC Slack (<a href="slack://channel?team=T04RY81HB&amp;id=C39V3PH38">open in app</a>) or <a href="mailto:hmrc-service-design-tools-g@digital.hmrc.gov.uk">email the Service Design Tools team</a></p>
             </div>
           </main>
           {{/if}}


### PR DESCRIPTION
Added the `mailto:` schem to the Email link in the design-system template so that it correctly triggers sending of email