### PR TITLE
Large images are now contained within the example containers

### DIFF
--- a/public/assets/stylesheets/design-system.css
+++ b/public/assets/stylesheets/design-system.css
@@ -1149,6 +1149,8 @@ main {
       line-height: 1.25;
       background: #6f777b;
       color: white; }
+    .markdown .example img {
+      max-width: 100%; }
   .markdown .column-one-third > h2 {
     padding-top: 30px;
     margin-top: 15px; }

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -110,6 +110,10 @@ main {
       background: $grey-1;
       color: white;
     }
+
+    img {
+      max-width: 100%;
+    }
   }
 
   .column-one-third > h2 {
@@ -302,7 +306,7 @@ dl.meta-data-bottom {
   h2 {
     margin-top: 0 !important;
     padding-top: 0;
-    max-width: 35em;    
+    max-width: 35em;
     &.heading-medium {
       @include media(mobile) {
         padding-top: $gutter-half;


### PR DESCRIPTION
# Problem
As in issue #64 the large images need to be contained within the example div containers
<img width="1398" alt="screen shot 2018-06-01 at 15 40 33" src="https://user-images.githubusercontent.com/10154302/40847399-2dfafb78-65b4-11e8-90de-9c4cb2daae0c.png">

# Solution
Add a rule for the images so they are set with a max width of 100%