### PR TITLE
Added styles for the Welsh examples in the example macros

### DIFF
--- a/public/assets/stylesheets/design-system.css
+++ b/public/assets/stylesheets/design-system.css
@@ -1132,6 +1132,7 @@ main {
 .markdown {
   margin: 0 32px 30px; }
   .markdown .example {
+    max-width: 34em;
     position: relative;
     border: 1px solid #bfc1c3;
     margin: 30px 0;
@@ -1151,6 +1152,14 @@ main {
       color: white; }
     .markdown .example img {
       max-width: 100%; }
+    .markdown .example title {
+      display: block; }
+  .markdown details .example {
+    margin-bottom: 0; }
+  .markdown details + pre {
+    display: none; }
+  .markdown details[open] + pre {
+    display: block; }
   .markdown .column-one-third > h2 {
     padding-top: 30px;
     margin-top: 15px; }
@@ -1233,12 +1242,13 @@ main {
     padding: 0; }
     .markdown > pre code {
       border: none; }
+    .markdown > pre + details {
+      margin-top: 30px; }
   .markdown > p,
   .markdown > ul,
   .markdown > ol,
   .markdown > blockquote,
-  .markdown > table,
-  .markdown > .example {
+  .markdown > table {
     max-width: 34em; }
   .markdown > ul {
     list-style: disc; }

--- a/public/assets/stylesheets/design-system/_custom.scss
+++ b/public/assets/stylesheets/design-system/_custom.scss
@@ -90,6 +90,7 @@ main {
   margin: 0 32px 30px;
 
   .example {
+    max-width: 34em;
     @extend %contain-floats;
     position: relative;
     border: 1px solid $border-colour;
@@ -114,7 +115,26 @@ main {
     img {
       max-width: 100%;
     }
+
+    title {
+      display: block;
+    }
   }
+
+  details {
+    .example {
+      margin-bottom: 0;
+    }
+    + pre {
+      display: none;
+    }
+  }
+  details[open]{
+    + pre {
+      display: block;
+    }
+  }
+
 
   .column-one-third > h2 {
     padding-top: 30px;
@@ -178,14 +198,16 @@ main {
     code {
       border: none;
     }
+    + details {
+      margin-top: 30px;
+    }
   }
 
   > p,
   > ul,
   > ol,
   > blockquote,
-  > table,
-  > .example {
+  > table {
     max-width: 34em;
   }
 


### PR DESCRIPTION
Added some basic styles used to space out the Welsh examples in documentation.
![screen shot 2018-06-14 at 14 38 38](https://user-images.githubusercontent.com/10154302/41416607-30953f9a-6fe3-11e8-8867-5be7aaeef2de.png)
