### PR TITLE
Scaled options not showing for Welsh examples...

### DIFF
--- a/public/assets/javascripts/design-system.js
+++ b/public/assets/javascripts/design-system.js
@@ -11,14 +11,6 @@
     }
   }
 
-  function scaleExampleHeight() {
-    var scaleWrapper = document.querySelectorAll('.scale-wrapper')
-
-    for (var i = 0, n = scaleWrapper.length; i < n; i++) {
-      scaleWrapper[i].style.height = scaleWrapper[i].querySelector('.scale').offsetHeight / 2 + 'px'
-    }
-  }
-
   function captureCopyEvents(){
     var codeBlocks = document.querySelectorAll('code')
     for (var i = 0, n = codeBlocks.length; i < n; i++){
@@ -26,8 +18,24 @@
         ga('send', 'event', 'markup', 'copy', document.location.pathname)
       })
     }
-
   }
+
+  function scaleExampleHeight() {
+    var scaleWrappers = Array.from(document.querySelectorAll('.scale-wrapper'))
+    scaleWrappers.forEach(function(el){
+      el.style.height = el.querySelector('.scale').clientHeight / 2 + 'px'
+    })
+  }
+
+  var detailsElement = Array.from(document.getElementsByTagName('details'));
+
+  detailsElement.forEach(function(el){
+    el.addEventListener('click', function(){
+      setTimeout(function(){
+        scaleExampleHeight()
+      },10)
+    })
+  })
 
   window.addEventListener('resize', function () {
     scaleExampleHeight()

--- a/public/assets/javascripts/design-system.js
+++ b/public/assets/javascripts/design-system.js
@@ -33,7 +33,7 @@
     el.addEventListener('click', function(){
       setTimeout(function(){
         scaleExampleHeight()
-      },10)
+      },100)
     })
   })
 


### PR DESCRIPTION
The Javascript function `scaleExampleHeight()` needed re-triggering when clicking on the `<details>` element as the Welsh example was not displaying when trying to toggle its display.